### PR TITLE
[FEAT] 팝업 전체 조회 API 구현

### DIFF
--- a/src/main/java/up/value/chefleaserver/controller/PopupController.java
+++ b/src/main/java/up/value/chefleaserver/controller/PopupController.java
@@ -1,0 +1,33 @@
+package up.value.chefleaserver.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import up.value.chefleaserver.domain.User;
+import up.value.chefleaserver.dto.PopupsGetResponse;
+import up.value.chefleaserver.service.PopupService;
+import up.value.chefleaserver.service.UserService;
+
+import java.security.Principal;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pop-ups")
+public class PopupController {
+
+    private final PopupService popupService;
+    private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<PopupsGetResponse> getAllPopups(Principal principal) {
+        User loginUser = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(popupService.getAllPopups(loginUser));
+    }
+}

--- a/src/main/java/up/value/chefleaserver/domain/Popup.java
+++ b/src/main/java/up/value/chefleaserver/domain/Popup.java
@@ -4,14 +4,22 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Popup {
 
@@ -24,11 +32,19 @@ public class Popup {
 
     private String image;
 
-    private String address;
-
     private LocalDate period;
 
     private LocalDateTime startTime;
 
     private LocalDateTime endTime;
+
+    @OneToMany(mappedBy = "popup")
+    private List<PopupCategory> popupCategories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "popup")
+    private List<PopupLike> popupLikes = new ArrayList<>();
+
+    @ManyToOne
+    @JoinColumn(name = "user_restaurant_id", nullable = false)
+    private UserRestaurant userRestaurant;
 }

--- a/src/main/java/up/value/chefleaserver/domain/PopupCategory.java
+++ b/src/main/java/up/value/chefleaserver/domain/PopupCategory.java
@@ -6,10 +6,13 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import up.value.chefleaserver.common.Category;
 
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
@@ -23,4 +26,8 @@ public class PopupCategory {
 
     @Enumerated(EnumType.STRING)
     private Category category;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "popup_id", nullable = false)
+    private Popup popup;
 }

--- a/src/main/java/up/value/chefleaserver/domain/PopupCategory.java
+++ b/src/main/java/up/value/chefleaserver/domain/PopupCategory.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import up.value.chefleaserver.common.Category;
 
@@ -16,6 +17,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PopupCategory {
 

--- a/src/main/java/up/value/chefleaserver/domain/PopupLike.java
+++ b/src/main/java/up/value/chefleaserver/domain/PopupLike.java
@@ -7,11 +7,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PopupLike {
 

--- a/src/main/java/up/value/chefleaserver/domain/PopupLike.java
+++ b/src/main/java/up/value/chefleaserver/domain/PopupLike.java
@@ -27,6 +27,6 @@ public class PopupLike {
     private User user;
 
     @ManyToOne
-    @JoinColumn(name = "popup_id",nullable = false)
+    @JoinColumn(name = "popup_id", nullable = false)
     private Popup popup;
 }

--- a/src/main/java/up/value/chefleaserver/domain/Restaurant.java
+++ b/src/main/java/up/value/chefleaserver/domain/Restaurant.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
@@ -16,6 +17,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Restaurant {
 

--- a/src/main/java/up/value/chefleaserver/domain/UserRestaurant.java
+++ b/src/main/java/up/value/chefleaserver/domain/UserRestaurant.java
@@ -7,12 +7,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserRestaurant {
 

--- a/src/main/java/up/value/chefleaserver/dto/PopupGetResponse.java
+++ b/src/main/java/up/value/chefleaserver/dto/PopupGetResponse.java
@@ -1,0 +1,46 @@
+package up.value.chefleaserver.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import up.value.chefleaserver.common.Category;
+import up.value.chefleaserver.domain.Popup;
+import up.value.chefleaserver.domain.PopupCategory;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PopupGetResponse(
+        Long popupId,
+        String popupImage,
+        List<String> popupCategories,
+        String popupName,
+        String popupAddress,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+        LocalDate popupPeriod,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+        LocalDateTime popupStartTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+        LocalDateTime popupEndTime,
+        String popupHeadChef,
+        Boolean isLiked
+
+) {
+    public static PopupGetResponse of(Popup popup, Boolean isLiked) {
+        return new PopupGetResponse(
+                popup.getId(),
+                popup.getImage(),
+                popup.getPopupCategories()
+                        .stream()
+                        .map(PopupCategory::getCategory)
+                        .map(Category::getKoreanLabel)
+                        .toList(),
+                popup.getName(),
+                popup.getUserRestaurant().getRestaurant().getAddress(),
+                popup.getPeriod(),
+                popup.getStartTime(),
+                popup.getEndTime(),
+                popup.getUserRestaurant().getUser().getName(),
+                isLiked
+        );
+    }
+}

--- a/src/main/java/up/value/chefleaserver/dto/PopupsGetResponse.java
+++ b/src/main/java/up/value/chefleaserver/dto/PopupsGetResponse.java
@@ -1,0 +1,11 @@
+package up.value.chefleaserver.dto;
+
+import java.util.List;
+
+public record PopupsGetResponse(
+    List<PopupGetResponse> popups
+) {
+    public static PopupsGetResponse of(List<PopupGetResponse> popupsGetResponse) {
+        return new PopupsGetResponse(popupsGetResponse);
+    }
+}

--- a/src/main/java/up/value/chefleaserver/repository/PopupRepository.java
+++ b/src/main/java/up/value/chefleaserver/repository/PopupRepository.java
@@ -1,0 +1,7 @@
+package up.value.chefleaserver.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import up.value.chefleaserver.domain.Popup;
+
+public interface PopupRepository extends JpaRepository<Popup, Long> {
+}

--- a/src/main/java/up/value/chefleaserver/service/PopupService.java
+++ b/src/main/java/up/value/chefleaserver/service/PopupService.java
@@ -1,0 +1,37 @@
+package up.value.chefleaserver.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import up.value.chefleaserver.domain.Popup;
+import up.value.chefleaserver.domain.PopupLike;
+import up.value.chefleaserver.domain.User;
+import up.value.chefleaserver.dto.PopupGetResponse;
+import up.value.chefleaserver.dto.PopupsGetResponse;
+import up.value.chefleaserver.repository.PopupRepository;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PopupService {
+
+    private final PopupRepository popupRepository;
+
+    @Transactional(readOnly = true)
+    public PopupsGetResponse getAllPopups(User loginUser) {
+        List<Popup> popups = popupRepository.findAll();
+
+        List<PopupGetResponse> popupGetResponses = popups.stream()
+                .map(popup -> {
+                    boolean isLiked = popup.getPopupLikes().stream().map(PopupLike::getUser)
+                            .toList()
+                            .contains(loginUser);
+                    return PopupGetResponse.of(popup, isLiked);
+                })
+                .toList();
+
+        return PopupsGetResponse.of(popupGetResponses);
+    }
+}


### PR DESCRIPTION
##  Related Issue 🍀

- close #4 


## Key Changes 🔑

- 고객(CLIENT) 사용자가 팝업 목록을 전체 조회할때 사용하는 API입니다.
- 기존의 Popup 엔티티의 주소와 Restaurant의 주소가 중복되어 제거했습니다. (UserRestaurant 외래키 참조를 통해 Restaurant 필드에 접근 하여 주소를 가져오는 방향으로 구현했습니다.)
- Category는 데이터 베이스에는 영어로 등록하고, 응답에는 한글로 반환합니다.


