### PR TITLE
[FEAT] 팝업 예약 전 팝업 정보 조회 API 구현

### DIFF
--- a/src/main/java/up/value/chefleaserver/controller/PopupController.java
+++ b/src/main/java/up/value/chefleaserver/controller/PopupController.java
@@ -39,4 +39,13 @@ public class PopupController {
                 .status(OK)
                 .body(popupService.getPopup(loginUser, popupId));
     }
+
+    @GetMapping("/{popupId}/reservations")
+    public ResponseEntity<PopupInfoForReservationResponse> getPopupInfoForReservation(Principal principal,
+                                                                                      @PathVariable("popupId") Long popupId) {
+        User loginUser = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(popupService.getPopupInfoForReservation(loginUser, popupId));
+    }
 }

--- a/src/main/java/up/value/chefleaserver/controller/PopupController.java
+++ b/src/main/java/up/value/chefleaserver/controller/PopupController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import up.value.chefleaserver.domain.User;
 import up.value.chefleaserver.dto.PopupDetailGetResponse;
+import up.value.chefleaserver.dto.PopupInfoForReservationResponse;
 import up.value.chefleaserver.dto.PopupsGetResponse;
 import up.value.chefleaserver.service.PopupService;
 import up.value.chefleaserver.service.UserService;

--- a/src/main/java/up/value/chefleaserver/domain/Popup.java
+++ b/src/main/java/up/value/chefleaserver/domain/Popup.java
@@ -46,6 +46,9 @@ public class Popup {
     @OneToMany(mappedBy = "popup")
     private List<Menu> popupmenus = new ArrayList<>();
 
+    @OneToMany(mappedBy = "popup")
+    private List<TimeTable> popupTimeTables = new ArrayList<>();
+
     @ManyToOne
     @JoinColumn(name = "user_restaurant_id", nullable = false)
     private UserRestaurant userRestaurant;

--- a/src/main/java/up/value/chefleaserver/domain/TimeTable.java
+++ b/src/main/java/up/value/chefleaserver/domain/TimeTable.java
@@ -12,9 +12,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TimeTable {
 

--- a/src/main/java/up/value/chefleaserver/domain/TimeTable.java
+++ b/src/main/java/up/value/chefleaserver/domain/TimeTable.java
@@ -30,6 +30,6 @@ public class TimeTable {
     private LocalDateTime endTime;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "user_popup_id", nullable = false)
-    private UserPopup userPopup;
+    @JoinColumn(name = "popup_id", nullable = false)
+    private Popup popup;
 }

--- a/src/main/java/up/value/chefleaserver/dto/PopupInfoForReservationResponse.java
+++ b/src/main/java/up/value/chefleaserver/dto/PopupInfoForReservationResponse.java
@@ -9,7 +9,7 @@ public record PopupInfoForReservationResponse(
         String popupName,
         String popupImage,
         String popupAddress,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yy.MM.dd")
         LocalDate popupPeriod,
         List<ReservationTableResponse> reservationTable
 ) {

--- a/src/main/java/up/value/chefleaserver/dto/PopupInfoForReservationResponse.java
+++ b/src/main/java/up/value/chefleaserver/dto/PopupInfoForReservationResponse.java
@@ -1,0 +1,15 @@
+package up.value.chefleaserver.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.util.List;
+
+public record PopupInfoForReservationResponse(
+        String popupName,
+        String popupImage,
+        String popupAddress,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+        LocalDate popupPeriod,
+        List<ReservationTableResponse> reservationTable
+) {
+}

--- a/src/main/java/up/value/chefleaserver/dto/PopupInfoForReservationResponse.java
+++ b/src/main/java/up/value/chefleaserver/dto/PopupInfoForReservationResponse.java
@@ -3,6 +3,7 @@ package up.value.chefleaserver.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.util.List;
+import up.value.chefleaserver.domain.Popup;
 
 public record PopupInfoForReservationResponse(
         String popupName,
@@ -12,4 +13,16 @@ public record PopupInfoForReservationResponse(
         LocalDate popupPeriod,
         List<ReservationTableResponse> reservationTable
 ) {
+    public static PopupInfoForReservationResponse of(Popup popup) {
+        return new PopupInfoForReservationResponse(
+                popup.getName(),
+                popup.getImage(),
+                popup.getUserRestaurant()
+                        .getRestaurant()
+                        .getAddress(),
+                popup.getPeriod(),
+                ReservationTableResponse
+                        .of(popup)
+        );
+    }
 }

--- a/src/main/java/up/value/chefleaserver/dto/ReservationTableResponse.java
+++ b/src/main/java/up/value/chefleaserver/dto/ReservationTableResponse.java
@@ -1,7 +1,6 @@
 package up.value.chefleaserver.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import java.sql.Time;
 import java.time.LocalDateTime;
 
 public record ReservationTableResponse(

--- a/src/main/java/up/value/chefleaserver/dto/ReservationTableResponse.java
+++ b/src/main/java/up/value/chefleaserver/dto/ReservationTableResponse.java
@@ -2,6 +2,8 @@ package up.value.chefleaserver.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
+import java.util.List;
+import up.value.chefleaserver.domain.Popup;
 
 public record ReservationTableResponse(
         Long reservationTimeId,
@@ -10,4 +12,14 @@ public record ReservationTableResponse(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
         LocalDateTime reservationEndTime
 ) {
+    public static List<ReservationTableResponse> of(Popup popup) {
+        return popup.getPopupTimeTables()
+                .stream()
+                .map(timeTable -> new ReservationTableResponse(
+                        timeTable.getId(),
+                        timeTable.getStartTime(),
+                        timeTable.getEndTime()
+                ))
+                .toList();
+    }
 }

--- a/src/main/java/up/value/chefleaserver/dto/ReservationTableResponse.java
+++ b/src/main/java/up/value/chefleaserver/dto/ReservationTableResponse.java
@@ -1,0 +1,14 @@
+package up.value.chefleaserver.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.sql.Time;
+import java.time.LocalDateTime;
+
+public record ReservationTableResponse(
+        Long reservationTimeId,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+        LocalDateTime reservationStartTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+        LocalDateTime reservationEndTime
+) {
+}

--- a/src/main/java/up/value/chefleaserver/service/PopupService.java
+++ b/src/main/java/up/value/chefleaserver/service/PopupService.java
@@ -8,6 +8,7 @@ import up.value.chefleaserver.domain.Popup;
 import up.value.chefleaserver.domain.User;
 import up.value.chefleaserver.dto.PopupDetailGetResponse;
 import up.value.chefleaserver.dto.PopupGetResponse;
+import up.value.chefleaserver.dto.PopupInfoForReservationResponse;
 import up.value.chefleaserver.dto.PopupsGetResponse;
 import up.value.chefleaserver.repository.PopupRepository;
 
@@ -38,5 +39,11 @@ public class PopupService {
         Popup popup = popupRepository.findById(popupId).orElseThrow(RuntimeException::new);
         boolean isLiked = userService.isLikedByUser(loginUser, popup);
         return PopupDetailGetResponse.of(popup, isLiked);
+    }
+
+    @Transactional(readOnly = true)
+    public PopupInfoForReservationResponse getPopupInfoForReservation(User loginUser, Long popupId) {
+        Popup popup = popupRepository.findById(popupId).orElseThrow(RuntimeException::new);
+        return PopupInfoForReservationResponse.of(popup);
     }
 }


### PR DESCRIPTION
##  Related Issue 🍀

- close #10 


## Key Changes 🔑

- TimeTable에 연관관계 변경 ( UserPopup -> Popup으로 외래키 설정 : https://github.com/CHEFLEA/Cheflea-Server/commit/d5eaf166a47d7029b4d9e1dcf3692eba8a47171e 커밋 메시지에 자세히 작성해둠)


## To Reviewers 🙏🏻

- ddl-auto: update 사용시 cascade로 테이블 지운 후 확인해주세요!
