### PR TITLE
[FEAT] 팝업 필터링 API 구현

### DIFF
--- a/src/main/java/up/value/chefleaserver/common/FilterCategory.java
+++ b/src/main/java/up/value/chefleaserver/common/FilterCategory.java
@@ -1,0 +1,8 @@
+package up.value.chefleaserver.common;
+
+public enum FilterCategory {
+    RECOMMENDATION,
+    PERIOD_DESC,
+    CREATED_TIME_DESC,
+    LIKE_DESC
+}

--- a/src/main/java/up/value/chefleaserver/controller/PopupController.java
+++ b/src/main/java/up/value/chefleaserver/controller/PopupController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import up.value.chefleaserver.common.FilterCategory;
 import up.value.chefleaserver.domain.User;
 import up.value.chefleaserver.dto.PopupDetailGetResponse;
 import up.value.chefleaserver.dto.PopupInfoForReservationResponse;
@@ -63,5 +64,14 @@ public class PopupController {
         return ResponseEntity
                 .status(CREATED)
                 .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<PopupsGetResponse> getFilteredPopups(Principal principal, @PathVariable("filter-category")
+    FilterCategory filterCategory) {
+        User loginUser = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(popupService.getFilteredPopups(loginUser, filterCategory));
     }
 }

--- a/src/main/java/up/value/chefleaserver/controller/PopupController.java
+++ b/src/main/java/up/value/chefleaserver/controller/PopupController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.security.Principal;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,15 +31,7 @@ public class PopupController {
     private final PopupService popupService;
     private final UserService userService;
 
-    @GetMapping
-    public ResponseEntity<PopupsGetResponse> getAllPopups(Principal principal) {
-        User loginUser = userService.getUserOrException(Long.valueOf(principal.getName()));
-        return ResponseEntity
-                .status(OK)
-                .body(popupService.getAllPopups(loginUser));
-    }
-
-    @GetMapping("/{popupId}")
+    @GetMapping("/{popupId:\\d+}")
     public ResponseEntity<PopupDetailGetResponse> getPopup(Principal principal, @PathVariable("popupId") Long popupId) {
         User loginUser = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
@@ -66,12 +59,14 @@ public class PopupController {
                 .build();
     }
 
-    @GetMapping
-    public ResponseEntity<PopupsGetResponse> getFilteredPopups(Principal principal, @PathVariable("filter-category")
-    FilterCategory filterCategory) {
+    @GetMapping(value = {"", "/{filter-category}", "/{search-keyword}", "/{filter-category}/{search-keyword}"})
+    public ResponseEntity<PopupsGetResponse> getFilteredPopups(Principal principal,
+                                                               @PathVariable("filter-category")
+                                                               Optional<FilterCategory> filterCategory,
+                                                               @PathVariable("search-keyword") Optional<String> searchKeyword) {
         User loginUser = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)
-                .body(popupService.getFilteredPopups(loginUser, filterCategory));
+                .body(popupService.getFilteredPopups(loginUser, filterCategory, searchKeyword));
     }
 }

--- a/src/main/java/up/value/chefleaserver/domain/Popup.java
+++ b/src/main/java/up/value/chefleaserver/domain/Popup.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,8 @@ public class Popup {
     private LocalTime startTime;
 
     private LocalTime endTime;
+
+    private LocalDateTime createdTime;
 
     @OneToMany(mappedBy = "popup")
     private List<PopupCategory> popupCategories = new ArrayList<>();

--- a/src/main/java/up/value/chefleaserver/domain/Popup.java
+++ b/src/main/java/up/value/chefleaserver/domain/Popup.java
@@ -64,6 +64,7 @@ public class Popup {
         this.period = restaurantPeriod;
         this.startTime = popupRegisterPostRequest.popupStartTime();
         this.endTime = popupRegisterPostRequest.popupEndTime();
+        this.createdTime = LocalDateTime.now();
         this.userRestaurant = userRestaurant;
     }
 

--- a/src/main/java/up/value/chefleaserver/repository/PopupRepository.java
+++ b/src/main/java/up/value/chefleaserver/repository/PopupRepository.java
@@ -1,7 +1,15 @@
 package up.value.chefleaserver.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import up.value.chefleaserver.domain.Popup;
 
 public interface PopupRepository extends JpaRepository<Popup, Long> {
+    List<Popup> findByNameContainingOrderByCreatedTimeDesc(String searchKeyword);
+
+    List<Popup> findByNameContainingOrderByPopupLikesDesc(String searchKeyword);
+
+    List<Popup> findByNameContainingOrderByPeriodDesc(String searchKeyword);
+
+    List<Popup> findByNameContainingOrderByPeriodDescCreatedTimeDescPopupLikesDesc(String searchKeyword);
 }

--- a/src/main/java/up/value/chefleaserver/service/PopupService.java
+++ b/src/main/java/up/value/chefleaserver/service/PopupService.java
@@ -1,9 +1,17 @@
 package up.value.chefleaserver.service;
 
+import static up.value.chefleaserver.common.FilterCategory.CREATED_TIME_DESC;
+import static up.value.chefleaserver.common.FilterCategory.LIKE_DESC;
+import static up.value.chefleaserver.common.FilterCategory.PERIOD_DESC;
+import static up.value.chefleaserver.common.FilterCategory.RECOMMENDATION;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import up.value.chefleaserver.common.FilterCategory;
 import up.value.chefleaserver.domain.Popup;
 import up.value.chefleaserver.domain.User;
 import up.value.chefleaserver.dto.PopupDetailGetResponse;


### PR DESCRIPTION
##  Related Issue 🍀

- close #41 


## Key Changes 🔑

- 기존의 팝업 전체 조회하기 메서드에 기능을 추가하는 방식으로 구현했습니다.
- 최근 등록순 카테고리가 있어 Popup 엔티티에 createdTime필드를 LocalDateTime으로 설정해두었습니다.
- createdTime 필드가 Popup 객체 생성 시점에 할당 되도록 하기 위해서 쉐프 - 팝업 등록하기 #24 에서 작성되었던 생성자에  `this.createdTime = LocalDateTime.now();` 코드 추가하였습니다.
- 컨트롤러의 getPopup 메소드의 url매핑한 것과 모호함의 문제가 발생할 수 있어 정규표현식 처리 해두었습니다. https://github.com/CHEFLEA/Cheflea-Server/commit/ab4dcb31cacc718a565ea102c28f4d19a4ad5966
`@GetMapping("/{popupId:\\d+}")`

## To Reviewers 🙏🏻

타입 불일치로 인한 문제가 생겨 정규표현식을 이용해보았습니다~
